### PR TITLE
Fix: CI to use toolchain from rust-toolchain.toml

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -54,7 +54,7 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('**/Cargo.toml') }}
       - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
         with:
           components: clippy
       - name: Install Dependencies
@@ -71,7 +71,7 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v4
       - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
         with:
           components: rustfmt
       - name: Run cargo fmt


### PR DESCRIPTION
The CI jobs for clippy and fmt were explicitly using the stable toolchain, ignoring the rust-toolchain.toml file which specifies nightly.

This change updates the dtolnay/rust-toolchain action to use `@master` instead of `@stable`, allowing it to pick up the toolchain specified in rust-toolchain.toml. This ensures that clippy and rustfmt components are installed for the correct (nightly) toolchain.